### PR TITLE
In case of whole repayment, force collateral withdrawal.

### DIFF
--- a/contracts/Interfaces/IPositionManager.sol
+++ b/contracts/Interfaces/IPositionManager.sol
@@ -260,11 +260,14 @@ interface IPositionManager is IFeeCollector {
     /// @param position The address of the borrower.
     /// @param collateralChange The amount of collateral to add or remove.
     /// @param isCollateralIncrease True if the collateral is being increased, false otherwise.
-    /// @param debtChange The amount of R to add or remove.
+    /// @param debtChange The amount of R to add or remove. In case of repayment (isDebtIncrease = false)
+    /// `type(uint256).max` value can be used to repay the whole outstanding loan.
     /// @param isDebtIncrease True if the debt is being increased, false otherwise.
     /// @param maxFeePercentage The maximum fee percentage to pay for the position management.
     /// @param permitSignature Optional permit signature for tokens that support IERC20Permit interface.
     /// @notice 'permitSignature' it is ignored if permit signature is not for 'collateralToken'.
+    /// @notice In case of full debt repayment, `isCollateralIncrease` and `collateralChange` are ignored.
+    /// These values are set to `false`(collateral decrease), and the whole collateral balance of the user.
     function managePosition(
         IERC20 collateralToken,
         address position,

--- a/contracts/PositionManager.sol
+++ b/contracts/PositionManager.sol
@@ -151,7 +151,12 @@ contract PositionManager is FeeCollector, IPositionManager {
             PermitHelper.applyPermit(permitSignature, msg.sender, address(this));
         }
 
-        bool newPosition = (raftDebtToken.balanceOf(position) == 0);
+        uint256 debtBefore = raftDebtToken.balanceOf(position);
+        if (isDebtIncrease == false && debtChange == type(uint256).max) {
+            isCollateralIncrease = false;
+            collateralChange = raftCollateralTokens[collateralToken].token.balanceOf(position);
+            debtChange = debtBefore;
+        }
 
         _adjustDebt(position, debtChange, isDebtIncrease, maxFeePercentage);
         _adjustCollateral(collateralToken, position, collateralChange, isCollateralIncrease);
@@ -168,7 +173,7 @@ contract PositionManager is FeeCollector, IPositionManager {
         } else {
             _checkValidPosition(collateralToken, positionDebt, positionCollateral);
 
-            if (newPosition) {
+            if (debtBefore == 0) {
                 collateralTokenForPosition[position] = collateralToken;
                 emit PositionCreated(position, collateralToken);
             }


### PR DESCRIPTION
Fixes #257 

On top of this fix, it adds a shortcut to repay the whole debt by passing `type(uint256).max`.