### PR TITLE
fix: Add Chainlink returndata additional validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ env:
   CI: true
   FORCE_COLOR: true
   MAINNET_RPC_URL: ${{ vars.MAINNET_RPC_URL }}
+  GOERLI_RPC_URL: ${{ vars.GOERLI_RPC_URL }}
 
 on:
   pull_request:

--- a/contracts/Oracles/Interfaces/IChainlinkPriceOracle.sol
+++ b/contracts/Oracles/Interfaces/IChainlinkPriceOracle.sol
@@ -13,6 +13,7 @@ interface IChainlinkPriceOracle is IPriceOracle {
         uint256 timestamp;
         bool success;
         uint8 decimals;
+        uint80 answeredInRound;
     }
 
     // --- Errors ---

--- a/test/ChainlinkPriceOracle.t.sol
+++ b/test/ChainlinkPriceOracle.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import { Test } from "forge-std/Test.sol";
+import { AggregatorV3Interface } from "../contracts/Dependencies/AggregatorV3Interface.sol";
+import { IWstETH } from "../contracts/Dependencies/IWstETH.sol";
+import { IPriceOracle } from "../contracts/Oracles/Interfaces/IPriceOracle.sol";
+import { ChainlinkPriceOracle } from "../contracts/Oracles/ChainlinkPriceOracle.sol";
+
+contract ChainlinkPriceOracleTest is Test {
+    AggregatorV3Interface public constant aggregatorV3StETH =
+        AggregatorV3Interface(0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8);
+    IWstETH public constant wstETH = IWstETH(0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0);
+    ChainlinkPriceOracle public chainlinkPriceOracle;
+
+    function setUp() public {
+        vm.createSelectFork("mainnet", 17_214_483);
+
+        chainlinkPriceOracle = new ChainlinkPriceOracle(aggregatorV3StETH, wstETH);
+    }
+
+    function testChainlinkWstETHPrice() public {
+        vm.warp(1_683_535_099);
+        IPriceOracle.PriceOracleResponse memory priceOracleResponse = chainlinkPriceOracle.getPriceOracleResponse();
+        assertEq(priceOracleResponse.isBrokenOrFrozen, false);
+        assertEq(priceOracleResponse.priceChangeAboveMax, false);
+        assertApproxEqAbs(priceOracleResponse.price, 2_084_356e15, 1e15);
+    }
+}

--- a/test/PriceFeed.t.sol
+++ b/test/PriceFeed.t.sol
@@ -23,6 +23,8 @@ contract PriceFeedTest is TestSetup {
     function setUp() public override {
         super.setUp();
 
+        vm.warp(100);
+
         randomAddress = makeAddr("randomAddress");
 
         mockChainlink = new MockChainlink();

--- a/test/mocks/MockChainlink.sol
+++ b/test/mocks/MockChainlink.sol
@@ -77,7 +77,7 @@ contract MockChainlink is AggregatorV3Interface {
     {
         if (latestRevert) require(1 == 0, "latestRoundData reverted");
 
-        return (latestRoundId, price, 0, updateTime, 0);
+        return (latestRoundId, price, 0, updateTime, latestRoundId);
     }
 
     function getRoundData(uint80)
@@ -88,7 +88,7 @@ contract MockChainlink is AggregatorV3Interface {
     {
         if (prevRevert) require(1 == 0, "getRoundData reverted");
 
-        return (prevRoundId, prevPrice, 0, updateTime, 0);
+        return (prevRoundId, prevPrice, 0, updateTime + prevRoundId - latestRoundId, prevRoundId);
     }
 
     function description() external pure override returns (string memory) {


### PR DESCRIPTION
From ToB issue
```
Short term, validate that timeStamp > 0 to ensure that the data is fresh. Also require(answeredInRound == roundId) to ensure the returned answer is not stale. Lastly check that the timeStamp value is not decreasing from round to round.
Long term, carefully investigate oracle integrations for potential footguns in order to conform to correct API usage.
```
1. `validate that timeStamp > 0` already exist and checked in function `_badChainlinkResponse`
2. `answeredInRound == roundId` is added in function `_badChainlinkResponse` as `response.answeredInRound != response.roundId` 
3. `Lastly check that the timeStamp value is not decreasing from round to round` added in the function `_chainlinkIsBroken` as `currentResponse.timestamp <= prevResponse.timestamp`